### PR TITLE
Handle situation when `stack ide targets` emits warning

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -33,7 +33,7 @@ export class Session implements vscode.Disposable {
                             }
                         )
                     });
-                    return ['stack', 'repl', '--no-load'].concat(result.split(/\r?\n/)).slice(0, -1);
+                    return ['stack', 'repl', '--no-load'].concat(result.match(/^[^\s]+$/gm));
                 } else if (wst == 'cabal')
                     return ['cabal', 'repl'];
                 else if (wst == 'bare-stack')


### PR DESCRIPTION
Which happens for instance when manually edited .cabal file is present

Example of warning:
```
D:\work\Haskell\SO>stack ide targets

Warning: D:\work\Haskell\SO\simple.cabal was modified manually. Ignoring
         D:\work\Haskell\SO\package.yaml in favor of the cabal file. If you want to use the
         package.yaml file instead of the cabal file, then please delete the cabal file.
simple:lib
simple:exe:simple-exe
simple:test:simple-test
```

The warning is then included as a part of `stack repl --no-load` command after which the extension does not emit any diagnostics.