### PR TITLE
Add cabal newstyle and cabal v2 support, default to newstyle

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Since around GHC 8, the compiler GHC and its interactive REPL GHCi has gained va
 
     Normally, vscode-ghc-simple will try to detect whether to use Stack or Cabal, or use a plain GHCi. Change this option *in your workspace settings* to specify such a type manually.
 
+    vscode-ghc-simple will default to Cabal new-style for workspaces with Cabal files.
+
 - `ghcSimple.startupCommands` and `ghcSimple.bareStartupCommands`
 
     Commands to run at GHCi startup. Configures some common options.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "url": "https://github.com/dramforever/vscode-ghc-simple"
     },
     "license": "ISC",
-    "version": "0.0.10",
+    "version": "0.0.8",
     "publisher": "dramforever",
     "engines": {
         "vscode": "^1.14.0"
@@ -42,7 +42,15 @@
                     "type": "string",
                     "default": "detect",
                     "description": "Workspace type, 'bare' means use GHCi directly",
-                    "enum": [ "detect", "stack", "cabal", "bare-stack", "bare" ]
+                    "enum": [
+                        "detect",
+                        "stack",
+                        "cabal",
+                        "cabal new",
+                        "cabal v2",
+                        "bare-stack",
+                        "bare"
+                    ]
                 },
                 "ghcSimple.startupCommands": {
                     "type": "array",
@@ -60,7 +68,9 @@
                     "items": {
                         "type": "string"
                     },
-                    "default": [ ":set -Wall" ],
+                    "default": [
+                        ":set -Wall"
+                    ],
                     "description": "Extra GHCi commands on startup to use for 'bare' workspace types"
                 }
             }

--- a/src/extension-state.ts
+++ b/src/extension-state.ts
@@ -2,7 +2,7 @@ import * as child_process from 'child_process';
 import * as vscode from 'vscode';
 import { Session } from './session';
 
-export type HaskellWorkspaceType = 'cabal' | 'stack' | 'bare-stack' | 'bare';
+export type HaskellWorkspaceType = 'cabal' | 'cabal new' | 'cabal v2' | 'stack' | 'bare-stack' | 'bare';
 
 export interface ExtensionState {
     context: vscode.ExtensionContext;
@@ -15,7 +15,7 @@ export interface ExtensionState {
 export async function startSession(ext: ExtensionState, doc: vscode.TextDocument): Promise<Session> {
     const wst = await ext.workspaceType;
     const session = (() => {
-        if (-1 !== ['stack', 'cabal'].indexOf(wst)) {
+        if (-1 !== ['stack', 'cabal', 'cabal new', 'cabal v2'].indexOf(wst)) {
             // stack or cabal
 
             if (ext.singleManager === null)
@@ -60,10 +60,10 @@ export async function computeWorkspaceType(): Promise<HaskellWorkspaceType> {
     const isStack = await vscode.workspace.findFiles('stack.yaml');
     if (isStack.length > 0)
         return 'stack';
-    
+
     const isCabal = await vscode.workspace.findFiles('**/*.cabal');
     if (isCabal.length > 0)
-        return 'cabal';
+        return 'cabal new';
 
     const hasStack = await new Promise<boolean>((resolve, reject) => {
             const cp = child_process.exec(

--- a/src/session.ts
+++ b/src/session.ts
@@ -36,6 +36,10 @@ export class Session implements vscode.Disposable {
                     return ['stack', 'repl', '--no-load'].concat(result.split(/\r?\n/)).slice(0, -1);
                 } else if (wst == 'cabal')
                     return ['cabal', 'repl'];
+                else if (wst == 'cabal new')
+                    return ['cabal', 'new-repl'];
+                else if (wst == 'cabal v2')
+                    return ['cabal', 'v2-repl'];
                 else if (wst == 'bare-stack')
                     return ['stack', 'exec', 'ghci'];
                 else if (wst == 'bare')


### PR DESCRIPTION
Tested this, works just fine for me. Awesome plugin.

Edit: It's possible to do v2 detection directly by looking in the cabal file at the start for a cabal-version stanza (because it's required to be at the start for all versions of cabal that use v2 IIRC) but I haven't done that here.