### PR TITLE
Single char range should have 1 char length

### DIFF
--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -46,7 +46,7 @@ function parseMessages(messages: string[]):
                     const line = num(2);
                     const col = num(3);
 
-                    return new vscode.Range(line - 1, col - 1, line - 1, col - 1);
+                    return new vscode.Range(line - 1, col - 1, line - 1, col);
                 } else if (res_heading[4]) {
                     // line:col-col
                     const line = num(4);


### PR DESCRIPTION
Otherwise VSCode error/warning range is effectively empty and does not include the entire error lexeme.
Example of the code which otherwise generates warning (type hole) with empty range:
```
f :: Bool
f = _
```
Similarly, the following code generates an error with empty range (provided that `a` is not in scope):
```
g :: Bool
g = a
```
Both of them should have ranges of length `1`.
The problem with empty ranges arises when we try to run VSCode code action for such error/warning (like replacing type hole with one of the valid hole fits).