### PR TITLE
Avoid truncation of -Werror error messages

### DIFF
--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -12,9 +12,9 @@ const regex = {
     // 4-6: variant 2: line:col-col
     // 7-10: variant 3: (line, col)
     message_base: /^(.+):(?:(\d+):(\d+)|(\d+):(\d+)-(\d+)|\((\d+),(\d+)\)-\((\d+),(\d+)\)): (.+)$/,
-    single_line_error: /^error: (.+)$/,
+    single_line_error: /^error: (?:\[.+\] )?([^\[].*)$/,
     single_line_warning: /^warning: \[(.+)\] (.+)$/,
-    error: /^error:$/,
+    error: /^error:(?: \[.*\])?$/,
     warning: /^warning: \[(.+)\]$/
 };
 


### PR DESCRIPTION
Demand that any single-line error message contains some non-bracketed content to avoid capturing "error: [-Wflag]" -Werror headings.

`single_line_error` _could_ be simpler if there are absolutely no (non-Werror) messages that start with `[`, but I don't know if that's the case.