### PR TITLE
Detect current ghci path to properly construct paths to definitions

### DIFF
--- a/src/definition.ts
+++ b/src/definition.ts
@@ -36,7 +36,8 @@ export function registerDefinition(ext: ExtensionState) {
 
         if (res.length == 1) {
             const loc = res[0];
-            return strToLocation(loc, vscode.workspace.getWorkspaceFolder(document.uri).uri.fsPath)
+            const basePath = session.basePath || vscode.workspace.getWorkspaceFolder(document.uri).uri.fsPath
+            return strToLocation(loc, basePath)
         } else {
             return null;
         }

--- a/src/session.ts
+++ b/src/session.ts
@@ -95,16 +95,16 @@ export class Session implements vscode.Disposable {
             try {
                 const res = await this.ghci.sendCommand(':show paths');
                 if (res.length < 1) {
-                    throw new Error('":show path" has too few lines');
+                    throw new Error('":show paths" has too few lines');
                 }
                 // expect second line of the output to be current ghci path
                 const basePath = res[1].trim();
                 if (basePath.length <= 0 || basePath[0] != '/') {
-                    throw new Error('invalid path value: ${basePath}');
+                    throw new Error('Invalid path value: ${basePath}');
                 }
                 const doesExist = await new Promise(resolve => fs.exists(basePath, resolve));
                 if (!doesExist) {
-                    throw new Error('detected path doesn\'t exist: ${basePath}');
+                    throw new Error('Detected path doesn\'t exist: ${basePath}');
                 }
                 this.ext.outputChannel.appendLine(`Detected base path: ${basePath}`);
                 this.basePath = basePath;


### PR DESCRIPTION
Currently a path to definition is constructed by combining path to workspace dir with the output of `:loc-at`.
In multi-package setup that doesn't work because `:loc-at` will output the path relative to a package (not workspace).

This fix detects ghci current path by running `:show paths` and uses it to create proper path to definition.

Note:
- `cabal new-repl all` (current default for `cabal new` workspace type) doesn't work for multi-package setup as well since repl cannot run more than one target. Not sure what fix can be appropriate here, though. I just use custom repl command.
- I'd also recommend to update `vsce` to the latest version since `npm` reports known vulnerabilities in the one currently in use. I haven't included this change because it causes massive updates to `package-lock.json` which I would rather leave for maintainer to manage.