### PR TITLE
Use `λ` instead of `GHC` in status bar

### DIFF
--- a/src/status-bar.ts
+++ b/src/status-bar.ts
@@ -24,6 +24,7 @@ export class StatusBar {
         this.bar = vscode.window.createStatusBarItem(
             vscode.StatusBarAlignment.Left);
         this.bar.command = "vscode-ghc-simple.openOutput";
+        this.bar.tooltip = "Simple GHC (Haskell) Integration";
 
         this.editorListener =
             vscode.window.onDidChangeActiveTextEditor(
@@ -44,7 +45,7 @@ export class StatusBar {
         const theStatus = theGhci && this.map.get(theGhci);
         const info = theStatus && theStatus.status == 'busy' && theStatus.info;
 
-        this.bar.text = ["GHC", counter, indicator, info]
+        this.bar.text = ["\u03BB", counter, indicator, info]
             .filter(x => x).join(" ");
     }
 


### PR DESCRIPTION
Thank you for implementing #55!
A small nitpick: looks like VSCode status bar prefers icons to text and even though there is no codicon for Haskell we still can use unicode:
![image](https://user-images.githubusercontent.com/722409/78831415-f2dde700-7a2c-11ea-867a-8ccc65d55602.png)
Also added static tooltip
