### PR TITLE
Show :doc info on hover

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,12 @@
                     "scope": "resource",
                     "description": "Enable inline GHCi REPL"
                 },
+                "ghcSimple.feature.documentation": {
+                    "type": "boolean",
+                    "default": true,
+                    "scope": "resource",
+                    "description": "Enable documentation on hover"
+                },
                 "ghcSimple.workspaceType": {
                     "type": "string",
                     "default": "detect",

--- a/src/documentation.ts
+++ b/src/documentation.ts
@@ -1,0 +1,47 @@
+import * as vscode from 'vscode';
+import { ExtensionState, startSession } from './extension-state';
+import { haskellSymbolRegex, haskellSelector, getFeatures } from './utils';
+import { Hover, MarkdownString } from 'vscode';
+
+export function registerDocumentation(ext: ExtensionState) {
+    async function provideHover(
+        document: vscode.TextDocument,
+        position: vscode.Position,
+        token: vscode.CancellationToken) {
+        if (! getFeatures(document.uri).documentation)
+            // Documentation disabled by user
+            return null;
+
+        const range = document.getWordRangeAtPosition(position, haskellSymbolRegex);
+
+        const session = await startSession(ext, document);
+        await session.loading;
+
+        await session.ghci.sendCommand(
+            `:module *${session.getModuleName(document.uri.fsPath)}`,
+            { token });
+
+        const cmd = `:doc ${document.getText(range)}`;
+        const response = await session.ghci.sendCommand(cmd, { token });
+
+        // Convert Haddock markup into Markdown so it can be displayed properly in hover
+        const documentation = response
+            .map(l => l.replace(/^$/m, "  "))
+            .join("\n")
+            .replace(/^\s/gm, "")
+            .replace(/^(=+)/gm, (_, $1) => $1.replace(/=/g, "#"))  // Header: ===
+            .replace(/@(.+?)@/gm, (_, $1) => `\`${$1.replace(/'(.+?)'/gm, "$1")}\``) // Code block: @...@
+            .replace(/(?<!\\)'(\S+)'(?<!\\)/gm, "`$1`")  // Hyperlinked definition: 'T'
+            .replace(/(?<!\\)"(\S+)"(?<!\\)/gm, "`$1`")  // Module: "Prelude"
+            .replace(/(?<!\\)\/(.+?)(?<!\\)\//g, "_$1_") // Emphasis: /.../ 
+            .replace(/(>>> .+$\n^.+)/gm, "```haskell\n$1\n```")  // Repl: >>>
+            .replace(/\[(.+?)\]:\s(.+)$/gm, "$1  \n&nbsp;&nbsp;&nbsp;&nbsp;$2  ")  // Definition list: [Element]:
+            .replace(/(?:^>(?!>).*\n?)+/gm, m => `\`\`\`haskell\n${m.replace(/^>(.*\n?)/gm, "$1")}\n\`\`\``) // Code block: >
+        return new Hover(new MarkdownString(documentation), range);
+    }
+
+    ext.context.subscriptions.push(
+        vscode.languages.registerHoverProvider(
+            haskellSelector,
+            { provideHover }));
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,7 @@ import { registerDefinition } from './definition';
 import { registerReference } from './reference';
 import { registerInlineRepl } from './inline-repl';
 import { StatusBar } from './status-bar'
+import { registerDocumentation } from './documentation';
 
 export function activate(context: vscode.ExtensionContext) {
     const outputChannel = vscode.window.createOutputChannel('GHC');
@@ -31,6 +32,7 @@ export function activate(context: vscode.ExtensionContext) {
     registerDefinition(ext);
     registerReference(ext);
     registerInlineRepl(ext);
+    registerDocumentation(ext);
 
     const diagInit = registerDiagnostics(ext);
 


### PR DESCRIPTION
The extension presently doesn't seem to define [HoverProvider](https://code.visualstudio.com/api/references/vscode-api#HoverProvider) so why don't we register it to show documentation provided by GHCi with [:doc](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/ghci.html#ghci-cmd-:doc) command?  
`:doc` returns documentation in [Haddock's markup](https://www.haskell.org/haddock/doc/html/ch03s08.html) format so to make it look nicer we also convert it to Markdown.

Example of usage:
![DocumentationOnHover](https://user-images.githubusercontent.com/722409/79318124-f2bc7a80-7f49-11ea-9742-ed150712d927.gif)
Resolves #12

