### PR TITLE
Fix Error Template Literals

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -121,11 +121,11 @@ export class Session implements vscode.Disposable {
                 // expect second line of the output to be current ghci path
                 const basePath = res[1].trim();
                 if (basePath.length <= 0 || basePath[0] != '/') {
-                    throw new Error('Invalid path value: ${basePath}');
+                    throw new Error(`Invalid path value: ${basePath}`);
                 }
                 const doesExist = await new Promise(resolve => fs.exists(basePath, resolve));
                 if (!doesExist) {
-                    throw new Error('Detected path doesn\'t exist: ${basePath}');
+                    throw new Error(`Detected path doesn\'t exist: ${basePath}`);
                 }
                 this.ext.outputChannel.appendLine(`Detected base path: ${basePath}`);
                 this.basePath = basePath;


### PR DESCRIPTION
Some errors use ` ' ` instead of `` ` `` so debugging messages are not very useful. This PR solves that