### PR TITLE
Code formatting through 'ormolu'

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,12 @@
                     "scope": "resource",
                     "description": "Enable documentation on hover"
                 },
+                "ghcSimple.feature.codeFormatting": {
+                    "type": "boolean",
+                    "default": true,
+                    "scope": "resource",
+                    "markdownDescription": "Enable code formatting through `ormolu`"
+                },
                 "ghcSimple.filterInfo": {
                     "type": "boolean",
                     "default": true,
@@ -192,7 +198,10 @@
                 },
                 "ghcSimple.inlineRepl.loadType": {
                     "type": "string",
-                    "enum": ["byte-code", "object-code"],
+                    "enum": [
+                        "byte-code",
+                        "object-code"
+                    ],
                     "default": "byte-code",
                     "markdownEnumDescriptions": [
                         "Use `-fbyte-code` for GHCi REPL blocks",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,8 +7,9 @@ import { registerDiagnostics } from './diagnostics';
 import { registerDefinition } from './definition';
 import { registerReference } from './reference';
 import { registerInlineRepl } from './inline-repl';
-import { StatusBar } from './status-bar'
 import { registerHover } from './hover';
+import { registerCodeFormatting } from './formatting';
+import { StatusBar } from './status-bar'
 
 export function activate(context: vscode.ExtensionContext) {
     const outputChannel = vscode.window.createOutputChannel('GHC');
@@ -33,6 +34,7 @@ export function activate(context: vscode.ExtensionContext) {
     registerReference(ext);
     registerInlineRepl(ext);
     registerHover(ext);
+    registerCodeFormatting(ext);
 
     const diagInit = registerDiagnostics(ext);
 

--- a/src/formatting.ts
+++ b/src/formatting.ts
@@ -1,0 +1,44 @@
+import * as vscode from 'vscode';
+import * as proc from 'child_process';
+import { haskellSelector, getFeatures } from './utils';
+import { ExtensionState } from './extension-state';
+
+// TODO: This could be eventually configured by the user (pick ormolu, brittany, hindent, etc...)
+const formatterCommand = 'ormolu'
+
+function provideDocumentRangeFormattingEdits(
+    document: vscode.TextDocument,
+    range: vscode.Range,
+    _: vscode.FormattingOptions,
+    __: vscode.CancellationToken
+): vscode.ProviderResult<vscode.TextEdit[]> {
+    if (!getFeatures(document.uri).codeFormatting) {
+        // Formatting disabled by the user
+        return null;
+    }
+    const text = document.getText(range);
+    let formattedText: string;
+    try {
+        formattedText = proc.execSync(formatterCommand, { input: text }).toString();
+        return [vscode.TextEdit.replace(range, formattedText)];
+    } catch (e) {
+        let cause: string = e.message
+            .replace(`Command failed: ${formatterCommand}`, '')
+            .replace(/:\s.*\n.*<stdin>/g, '')
+            .trim()
+        vscode.window.showErrorMessage(`Ormolu failed to format the code. ${cause}`);
+    }
+    return [];
+}
+
+export function registerCodeFormatting(ext: ExtensionState) {
+    try {
+        proc.execSync(`${formatterCommand} --help`);
+        ext.context.subscriptions.push(vscode.languages.registerDocumentRangeFormattingEditProvider(
+            haskellSelector,
+            { provideDocumentRangeFormattingEdits }
+        ));
+    } catch (e) {
+        vscode.window.showWarningMessage("Ormolu is not installed. Code formatting is disabled");
+    }
+} 


### PR DESCRIPTION
Adds code formatting through [ormolu](https://github.com/tweag/ormolu), an opinionated code formatter.

The code is really short, and the feature can be disabled from the user `settings.json` setting `ghcSimple.feature.codeFormatting` to `false`

This is probably out of the scope of this extension, but the implementation is so short that I could not resist adding it.