### PR TITLE
Expose public API

### DIFF
--- a/src/extension-state.ts
+++ b/src/extension-state.ts
@@ -2,6 +2,7 @@ import * as child_process from 'child_process';
 import * as vscode from 'vscode';
 import { Session } from './session';
 import { StatusBar } from './status-bar';
+import { GhciOptions } from './ghci';
 
 export type HaskellWorkspaceType = 'custom-workspace' | 'custom-file' | 'cabal' | 'cabal new' | 'cabal v2' | 'stack' | 'bare-stack' | 'bare';
 
@@ -21,7 +22,7 @@ function getWorkspaceType(ext: ExtensionState, folder: vscode.WorkspaceFolder): 
     return ext.workspaceTypeMap.get(folder);
 }
 
-export async function startSession(ext: ExtensionState, doc: vscode.TextDocument): Promise<Session> {
+export async function startSession(ext: ExtensionState, doc: vscode.TextDocument, ghciOptions: GhciOptions = new GhciOptions): Promise<Session> {
     const folder = vscode.workspace.getWorkspaceFolder(doc.uri);
     const type = folder === undefined
         ? await computeFileType()
@@ -33,7 +34,7 @@ export async function startSession(ext: ExtensionState, doc: vscode.TextDocument
 
             if (! ext.workspaceManagers.has(folder))
                 ext.workspaceManagers.set(folder,
-                    new Session(ext, type, 'workspace', folder.uri));
+                    new Session(ext, type, 'workspace', folder.uri, ghciOptions));
 
             return ext.workspaceManagers.get(folder);
         } else {
@@ -41,7 +42,7 @@ export async function startSession(ext: ExtensionState, doc: vscode.TextDocument
 
             if (! ext.documentManagers.has(doc))
                 ext.documentManagers.set(doc,
-                    new Session(ext, type, 'file', doc.uri));
+                    new Session(ext, type, 'file', doc.uri, ghciOptions));
 
             return ext.documentManagers.get(doc);
         }

--- a/src/extension-state.ts
+++ b/src/extension-state.ts
@@ -9,7 +9,7 @@ export type HaskellWorkspaceType = 'custom-workspace' | 'custom-file' | 'cabal' 
 export interface ExtensionState {
     context: vscode.ExtensionContext;
     outputChannel: vscode.OutputChannel;
-    statusBar: StatusBar;
+    statusBar?: StatusBar;
     workspaceTypeMap: Map<vscode.WorkspaceFolder, Promise<HaskellWorkspaceType>>;
     documentManagers: Map<vscode.TextDocument, Session>;
     workspaceManagers: Map<vscode.WorkspaceFolder, Session>;

--- a/src/ghci.ts
+++ b/src/ghci.ts
@@ -68,13 +68,13 @@ export class GhciManager implements Disposable {
     }
 
     idle() {
-        this.ext.statusBar.update(this, {
+        this.ext.statusBar && this.ext.statusBar.update(this, {
             status: 'idle'
         });
     }
 
     busy(info: string | null = null) {
-        this.ext.statusBar.update(this, {
+        this.ext.statusBar && this.ext.statusBar.update(this, {
             status: 'busy',
             info
         })
@@ -254,7 +254,7 @@ export class GhciManager implements Disposable {
     dispose() {
         this.wasDisposed = true;
 
-        this.ext.statusBar.remove(this);
+        this.ext.statusBar && this.ext.statusBar.remove(this);
         if (this.proc !== null) {
             this.proc.kill();
             this.proc = null;

--- a/src/ghci.ts
+++ b/src/ghci.ts
@@ -20,6 +20,19 @@ interface PendingCommand extends StrictCommandConfig {
     reject: (reason: any) => void;
 }
 
+export class GhciOptions {
+    startOptions?: string;
+    reloadCommands?: string[] = [
+        ":set -fno-code",
+        ":set +c"
+    ];
+    startupCommands: {
+        all?: string[];
+        bare?: string[];
+        custom?: string[];
+    } = {}
+}
+
 export class GhciManager implements Disposable {
     proc: child_process.ChildProcess | null;
     command: string;


### PR DESCRIPTION
### Goal
Allow other extensions to use GHCi via `vscode-ghc-simple` extension public API.  

### Why
`vscode-ghc-simple` does fantastic job at managing GHCi (including various Haskell configurations and stuff) and with this change in place other extensions [can re-use](https://code.visualstudio.com/api/references/vscode-api#extensions) GHCi via `vscode-ghc-simple` as a wrapper.  
I believe there is no other way to re-use your code otherwise without copy/pasting it.  

### API
As for the proposed API: as you can see it currently exposes only one method `startApi` which returns [Api](https://github.com/EduardSergeev/vscode-ghc-simple/blob/d5d1f7fa410462f6e7a9bebe7e257fd703d77a4b/src/extension.ts#L80-L92) interface and internally creates a new instance of `ExtensionState` which will effectively create a separate instance of GHCi when a caller of `Api` calls its only method [startSession](https://github.com/EduardSergeev/vscode-ghc-simple/blob/d5d1f7fa410462f6e7a9bebe7e257fd703d77a4b/src/extension.ts#L91).  

### Effect on existing code
Unfortunately apart from exposing existing functionality, to make Api more flexible, more configurable, I had to slightly modify existing code by:
- extracting configurable parameters into [GhciOptions](https://github.com/EduardSergeev/vscode-ghc-simple/blob/d5d1f7fa410462f6e7a9bebe7e257fd703d77a4b/src/ghci.ts#L23-L34) class which is now [passed as default parameter](https://github.com/EduardSergeev/vscode-ghc-simple/blob/d5d1f7fa410462f6e7a9bebe7e257fd703d77a4b/src/session.ts#L25) to `Session`;
- modifying your code to allow `null` to be passed as `StatusBar` parameter so sandbox-ed GHCi session could run without corresponding status bar.

Both changes, I believe, are non-breaking and the rest of the code can just ignore them.
**PS:** I am also opening #68 which requires more changes in you code but exposes nice API. So it is either this #67 change or that #68, not both. 

### Would be great to have it!
Please consider merging this change to allow other developers to build on top of your work without copy/pasting your code :)  
I understand that it probably does not add anything to your extension and even adds a bit of extra maintenance but it would be really great if you expose your work in this or similar format, very useful for me and possible to other extension authors. 