### PR TITLE
Public API V2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1019,9 +1019,9 @@
             }
         },
         "typescript": {
-            "version": "2.9.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-            "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+            "version": "3.8.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+            "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
             "dev": true
         },
         "uc.micro": {

--- a/package.json
+++ b/package.json
@@ -223,7 +223,7 @@
     },
     "devDependencies": {
         "@types/node": "^6.14.9",
-        "typescript": "^2.9.2",
+        "typescript": "^3.8.3",
         "vsce": "^1.75.0",
         "vscode": "^1.1.36"
     }

--- a/src/extension-state.ts
+++ b/src/extension-state.ts
@@ -2,6 +2,7 @@ import * as child_process from 'child_process';
 import * as vscode from 'vscode';
 import { Session } from './session';
 import { StatusBar } from './status-bar';
+import { GhciOptions } from './ghci';
 
 export type HaskellWorkspaceType = 'custom-workspace' | 'custom-file' | 'cabal' | 'cabal new' | 'cabal v2' | 'stack' | 'bare-stack' | 'bare';
 
@@ -21,7 +22,7 @@ function getWorkspaceType(ext: ExtensionState, folder: vscode.WorkspaceFolder): 
     return ext.workspaceTypeMap.get(folder);
 }
 
-export async function startSession(ext: ExtensionState, doc: vscode.TextDocument): Promise<Session> {
+export async function startSession(ext: ExtensionState, doc: vscode.TextDocument, ghciOptions: GhciOptions = new GhciOptions): Promise<Session> {
     const folder = vscode.workspace.getWorkspaceFolder(doc.uri);
     const type = folder === undefined
         ? await computeFileType()
@@ -33,7 +34,7 @@ export async function startSession(ext: ExtensionState, doc: vscode.TextDocument
 
             if (! ext.workspaceManagers.has(folder))
                 ext.workspaceManagers.set(folder,
-                    new Session(ext, type, 'workspace', folder.uri));
+                    new Session(ext, type, 'workspace', folder.uri, ghciOptions));
 
             return ext.workspaceManagers.get(folder);
         } else {
@@ -41,7 +42,7 @@ export async function startSession(ext: ExtensionState, doc: vscode.TextDocument
 
             if (! ext.documentManagers.has(doc))
                 ext.documentManagers.set(doc,
-                    new Session(ext, type, 'file', doc.uri));
+                    new Session(ext, type, 'file', doc.uri, ghciOptions));
 
             return ext.documentManagers.get(doc);
         }

--- a/src/extension-state.ts
+++ b/src/extension-state.ts
@@ -9,7 +9,7 @@ export type HaskellWorkspaceType = 'custom-workspace' | 'custom-file' | 'cabal' 
 export interface ExtensionState {
     context: vscode.ExtensionContext;
     outputChannel: vscode.OutputChannel;
-    statusBar: StatusBar;
+    statusBar?: StatusBar;
     workspaceTypeMap: Map<vscode.WorkspaceFolder, Promise<HaskellWorkspaceType>>;
     documentManagers: Map<vscode.TextDocument, Session>;
     workspaceManagers: Map<vscode.WorkspaceFolder, Session>;

--- a/src/extension-state.ts
+++ b/src/extension-state.ts
@@ -8,7 +8,7 @@ export type HaskellWorkspaceType = 'custom-workspace' | 'custom-file' | 'cabal' 
 
 export interface ExtensionState {
     context: vscode.ExtensionContext;
-    outputChannel: vscode.OutputChannel;
+    outputChannel?: vscode.OutputChannel;
     statusBar?: StatusBar;
     workspaceTypeMap: Map<vscode.WorkspaceFolder, Promise<HaskellWorkspaceType>>;
     documentManagers: Map<vscode.TextDocument, Session>;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -57,7 +57,7 @@ export function activate(context: vscode.ExtensionContext) {
     }
 
     function openOutput() {
-        ext.outputChannel.show();
+        ext.outputChannel?.show();
     }
 
     context.subscriptions.push(
@@ -79,10 +79,6 @@ export function activate(context: vscode.ExtensionContext) {
      */
     interface Api {
         /**
-         * [output channel](#vscode.OutputChannel) containing GHCi output
-         */
-        outputChannel: vscode.OutputChannel;
-        /**
          * Create a new GHCi session
          * @param doc Current document
          * @param ghciOptions Various options to be passed to GHCi
@@ -96,13 +92,13 @@ export function activate(context: vscode.ExtensionContext) {
          * Create new instance of Simple GHC API  
          * Call this function only once, probably during extension activation
          * @param context Calling extension context
-         * @param channel Output channel for GHCi output. New session will use existing `GHC` channel if ommited
+         * @param outputChannel Output channel for GHCi output. No output will be logged if omitted.
          * @returns Simple GHC `Api`
          */
-        startApi(context: vscode.ExtensionContext, channel?: vscode.OutputChannel): Api {
+        startApi(context: vscode.ExtensionContext, outputChannel?: vscode.OutputChannel): Api {
             const ext = {
                 context,
-                outputChannel: channel || outputChannel,
+                outputChannel: outputChannel,
                 statusBar: null,
                 documentManagers: new Map(),
                 workspaceManagers: new Map(),
@@ -110,7 +106,6 @@ export function activate(context: vscode.ExtensionContext) {
                 documentAssignment: new WeakMap()
             };
             return {
-                outputChannel: ext.outputChannel,
                 startSession: (doc, ghciOptions?) =>
                     startSession(ext, doc, ghciOptions)
             };

--- a/src/ghci.ts
+++ b/src/ghci.ts
@@ -26,7 +26,7 @@ export class GhciOptions {
         ":set -fno-code",
         ":set +c"
     ];
-    startupCommands: {
+    startupCommands?: {
         all?: string[];
         bare?: string[];
         custom?: string[];
@@ -64,17 +64,17 @@ export class GhciManager implements Disposable {
     }
 
     outputLine(line: string) {
-        this.ext.outputChannel.appendLine(line);
+        this.ext.outputChannel?.appendLine(line);
     }
 
     idle() {
-        this.ext.statusBar && this.ext.statusBar.update(this, {
+        this.ext.statusBar?.update(this, {
             status: 'idle'
         });
     }
 
     busy(info: string | null = null) {
-        this.ext.statusBar && this.ext.statusBar.update(this, {
+        this.ext.statusBar?.update(this, {
             status: 'busy',
             info
         })
@@ -254,7 +254,7 @@ export class GhciManager implements Disposable {
     dispose() {
         this.wasDisposed = true;
 
-        this.ext.statusBar && this.ext.statusBar.remove(this);
+        this.ext.statusBar?.remove(this);
         if (this.proc !== null) {
             this.proc.kill();
             this.proc = null;

--- a/src/ghci.ts
+++ b/src/ghci.ts
@@ -68,13 +68,13 @@ export class GhciManager implements Disposable {
     }
 
     idle() {
-        this.ext.statusBar.update(this, {
+        this.ext.statusBar && this.ext.statusBar.update(this, {
             status: 'idle'
         });
     }
 
     busy(info: string | null = null) {
-        this.ext.statusBar.update(this, {
+        this.ext.statusBar && this.ext.statusBar.update(this, {
             status: 'busy',
             info
         })
@@ -254,7 +254,7 @@ export class GhciManager implements Disposable {
     dispose() {
         this.wasDisposed = true;
 
-        this.ext.statusBar.remove(this);
+        this.ext.statusBar && this.ext.statusBar.remove(this);
         if (this.proc !== null) {
             this.proc.kill();
             this.proc = null;

--- a/src/ghci.ts
+++ b/src/ghci.ts
@@ -20,6 +20,19 @@ interface PendingCommand extends StrictCommandConfig {
     reject: (reason: any) => void;
 }
 
+export class GhciOptions {
+    startOptions?: string;
+    reloadCommands?: string[] = [
+        ":set -fno-code",
+        ":set +c"
+    ];
+    startupCommands: {
+        all?: string[];
+        bare?: string[];
+        custom?: string[];
+    } = {}
+}
+
 export class GhciManager implements Disposable {
     proc: child_process.ChildProcess | null;
     command: string;

--- a/src/session.ts
+++ b/src/session.ts
@@ -52,7 +52,7 @@ export class Session implements vscode.Disposable {
                 ).then(
                     (item) => {
                         if (item === 'Open log') {
-                            this.ext.outputChannel.show();
+                            this.ext.outputChannel?.show();
                         }
                     },
                     (err) => console.error(err)
@@ -106,8 +106,8 @@ export class Session implements vscode.Disposable {
                     return `ghci${this.getStartOptions(' ')}`;
             })();
 
-            this.ext.outputChannel.appendLine(`Starting GHCi with: ${JSON.stringify(cmd)}`);
-            this.ext.outputChannel.appendLine(
+            this.ext.outputChannel?.appendLine(`Starting GHCi with: ${JSON.stringify(cmd)}`);
+            this.ext.outputChannel?.appendLine(
                 `(Under ${
                     this.cwdOption.cwd === undefined
                         ? 'default cwd'
@@ -120,9 +120,9 @@ export class Session implements vscode.Disposable {
                 this.ext);
             const cmds = vscode.workspace.getConfiguration('ghcSimple.startupCommands', this.resource);
             const configureCommands = [].concat(
-                this.ghciOptions.startupCommands.all || cmds.all,
-                wst === 'bare-stack' || wst === 'bare' ? this.ghciOptions.startupCommands.bare || cmds.bare : [],
-                this.ghciOptions.startupCommands.custom || cmds.custom
+                this.ghciOptions.startupCommands?.all || cmds.all,
+                wst === 'bare-stack' || wst === 'bare' ? this.ghciOptions.startupCommands?.bare || cmds.bare : [],
+                this.ghciOptions.startupCommands?.custom || cmds.custom
             );
             await this.ghci.sendCommand(configureCommands);
 
@@ -140,11 +140,11 @@ export class Session implements vscode.Disposable {
                 if (!doesExist) {
                     throw new Error(`Detected path doesn\'t exist: ${basePath}`);
                 }
-                this.ext.outputChannel.appendLine(`Detected base path: ${basePath}`);
+                this.ext.outputChannel?.appendLine(`Detected base path: ${basePath}`);
                 this.basePath = basePath;
             } catch(e) {
-                this.ext.outputChannel.appendLine(`Error detecting base path: ${e}`);
-                this.ext.outputChannel.appendLine('Will fallback to document\'s workspace folder');
+                this.ext.outputChannel?.appendLine(`Error detecting base path: ${e}`);
+                this.ext.outputChannel?.appendLine('Will fallback to document\'s workspace folder');
             }
         }
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -40,7 +40,7 @@ export function getFeatures(resource: vscode.Uri): { [k: string]: any } {
 export function reportError(ext: ExtensionState, msg: string) {
     return (err) => {
         console.error(`${msg}: ${err}`);
-        ext.outputChannel.appendLine(`${msg}: ${err}`);
+        ext.outputChannel?.appendLine(`${msg}: ${err}`);
     }
 }
 


### PR DESCRIPTION
It is a slightly modified version of API proposed in #67  which I actually prefer but which also makes further modification in your code.  

Should you decide to merge my changes please merge ether #67 or this #68.

The difference is that when `startApi` is called without `outputChannel` it now simply will not output anything (instead of using `GHC` output channel) which I think is cleaner (more "sandbox"-like).  
And to implement this change succinctly I had to upgrade the project to TypeScript from 2.9.2 to 3.8.3 to use [optional chaining](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#optional-chaining).

If anything is getting merged eventually I would prefer **this V2 version** to be added **instead of** #67 but I do realise that it is a major upgrade of a language used (on the other hand why would you like to be stuck in 2018 with 2.9.2? :) )