### PR TITLE
Honor ghcSimple.replCommand setting for files opened outside workspace

### DIFF
--- a/src/extension-state.ts
+++ b/src/extension-state.ts
@@ -84,8 +84,10 @@ function hasStack(cwd?: string): Promise<boolean> {
 }
 
 export async function computeFileType(): Promise<HaskellWorkspaceType> {
-    if (await hasStack())
-        return 'bare-stack'
+    if (vscode.workspace.getConfiguration('ghcSimple').replCommand)
+        return 'custom-file';
+    else if (await hasStack())
+        return 'bare-stack';
     else
         return 'bare';
 }


### PR DESCRIPTION
Use the command specified in `ghcSimple.replCommand` to start GHCi session when Haskell source file is opened outside workspace (User's settings in this case)
Fixes #81 