### PR TITLE
Fix diagnostics parsing for GHC versions after 9.6.*

### DIFF
--- a/src/features/diagnostics.ts
+++ b/src/features/diagnostics.ts
@@ -105,7 +105,7 @@ function parseMessages(messages: string[]):
                 while (messages.length > 0 && messages[0].startsWith('    ')) {
                     msgs.push(messages.shift().substr(4));
                 }
-                const msg = msgs.join('\n') + (msgs.length ? '\n' : '');
+                const msg = msgs.join('\n');
 
                 const severity: vscode.DiagnosticSeverity = (() => {
                     if (res_error !== null) {

--- a/src/features/diagnostics.ts
+++ b/src/features/diagnostics.ts
@@ -13,9 +13,9 @@ const regex = {
     // 7-10: variant 3: (line, col)
     message_base: /^(.+):(?:(\d+):(\d+)|(\d+):(\d+)-(\d+)|\((\d+),(\d+)\)-\((\d+),(\d+)\)): (.+)$/,
     single_line_error: /^error: (?:\[.+\] )?([^\[].*)$/,
-    single_line_warning: /^warning: \[(.+)\] (.+)$/,
+    single_line_warning: /^warning: (?:\[GHC-.+\] )?\[(-W.+)\] (.*)$/,
     error: /^error:(?: \[.*\])?$/,
-    warning: /^warning:(?: \[(.+)\])?$/
+    warning: /^warning: (?:\[GHC-.+\] )?\[(-W.+)\]$/
 };
 
 interface DiagnosticWithFile {


### PR DESCRIPTION
this pull request resolves issue #98, and includes a fix for extra newlines.

thanks to @EduardSergeev for helping troubleshooting the issue!