### PR TITLE
update Haskell Syntax Highlighting

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "haskell"
     ],
     "extensionDependencies": [
-        "justusadam.language-haskell"
+        "haskell.language-haskell"
     ],
     "icon": "images/vgs-icon.png",
     "activationEvents": [


### PR DESCRIPTION
The Haskell syntax highlighting extension `justusadam.language-haskell` was recently renamed to `haskell.language-haskell`, after maintenance was transferred to the Haskell community. See haskell/language-haskell#256.

Since the old `justusadam.language-haskell` package is no longer available on the Marketplace, Simple GHC Integration can fail to start.

This PR updates the extension dependency accordingly, so that Simple GHC Integration starts without requiring the obsolete package.
